### PR TITLE
adding option to select the position of currency symbol

### DIFF
--- a/Model/Config/Source/SymbolPosition.php
+++ b/Model/Config/Source/SymbolPosition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EW\CurrencySymbolPosition\Model\Config\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class SymbolPosition implements ArrayInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => 'default', 'label' => __('Use locale default')],
+            ['value' => 'left', 'label' => __('Left')],
+            ['value' => 'right', 'label' => __('Right')],
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -3,11 +3,15 @@
     <system>
         <section id="currency">
             <group id="options">
-                <field id="currency_symbol_position" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Show currency symbol to the right</label>
-                    <comment>This setting makes the currency symbol render to the right</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>currency/options/symbol_position</config_path>
+                <field id="symbol_position" translate="label comment"
+                       type="select"
+                       sortOrder="90"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1">
+                    <label>Currency Symbol Position</label>
+                    <comment>Select where to display the currency symbol.</comment>
+                    <source_model>EW\CurrencySymbolPosition\Model\Config\Source\SymbolPosition</source_model>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/config.xsd">
+    <default>
+        <currency>
+            <options>
+                <symbol_position>default</symbol_position>
+            </options>
+        </currency>
+    </default>
+</config>


### PR DESCRIPTION
The current version of the extension only checked whether the currency symbol should be displayed on the right side. With these changes, it's possible to display the currency symbol on both the right and left sides of the amount. This is especially useful for locale fr_CH. Here, the currency symbol is displayed on the right, even though it should be displayed before the amount, as in de_CH.